### PR TITLE
test: remove Node.js 9 from Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: node_js
 node_js:
   - 6
   - 8
-  - 9
   - 10
 
 os:


### PR DESCRIPTION
Node.js 9 is in an End-of-life state at the moment.