### PR TITLE
npm: add missing file to npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "!src/unicode_tables.h",
     "dist/",
     "binding.gyp",
-    "tools/build-native.js"
+    "tools/build-native.js",
+    "tools/make-unicode-tables.js"
   ],
   "scripts": {
     "test": "npm run lint && npm run test-node",


### PR DESCRIPTION
Add file required for package installation since https://github.com/metarhia/mdsf/pull/9 to package.json files field.

Unfortunately, we've overlooked this problem in #9 and package installation would always fail without it, so I've had to publish the version 1.0.0 of this package to npm with this change, to avoid almost immediate unpublishing.