### PR TITLE
parser: improve overall parser performance

### DIFF
--- a/src/parser.cc
+++ b/src/parser.cc
@@ -86,9 +86,7 @@ static constexpr MaybeLocal<Value> (*kParseFunctions[])(Isolate*,
   &internal::ParseObject
 };
 
-Local<Value> Parse(Isolate* isolate, const String::Utf8Value& in) {
-  const char* str = *in;
-  const size_t length = in.length();
+Local<Value> Parse(Isolate* isolate, const char* str, size_t length) {
   const char* end = str + length;
 
   Type type;

--- a/src/parser.h
+++ b/src/parser.h
@@ -17,7 +17,8 @@ namespace parser {
 // Deserializes a UTF-8 encoded string into a JavaScript value
 // and returns a handle to it.
 v8::Local<v8::Value> Parse(v8::Isolate* isolate,
-                           const v8::String::Utf8Value& in);
+                           const char* str,
+                           std::size_t length);
 
 namespace internal {
 


### PR DESCRIPTION
* Slightly improve string parsing performance.
* Highly improve parsing performance for Buffers by
  avoiding toString conversion (leading to copying data).

Refs: https://github.com/metarhia/jstp/pull/254