### PR TITLE
parser: refactor native parseJSTPMessages

### DIFF
--- a/src/message_parser.h
+++ b/src/message_parser.h
@@ -6,17 +6,21 @@
 #ifndef SRC_MESSAGE_PARSER_H_
 #define SRC_MESSAGE_PARSER_H_
 
+#include <cstddef>
+
 #include <v8.h>
 
 namespace mdsf {
 
 namespace message_parser {
 
+const char kMessageTerminator = '\0';
+
 // Efficiently parses JSTP messages for transports that require message
 // delimiters eliminating the need to split the stream data into parts before
 // parsing and allowing to do that in one pass.
 v8::Local<v8::String> ParseJSTPMessages(v8::Isolate* isolate,
-    const v8::String::Utf8Value& in, v8::Local<v8::Array> out);
+    const char* str, std::size_t length, v8::Local<v8::Array> out);
 
 }  // namespace message_parser
 

--- a/src/node_bindings.cc
+++ b/src/node_bindings.cc
@@ -80,8 +80,10 @@ void ParseJSTPMessages(const FunctionCallbackInfo<Value>& args) {
 #endif
       args[0]->ToString()
   );
+  std::size_t length = str.length();
   auto array = args[1].As<Array>();
-  auto result = mdsf::message_parser::ParseJSTPMessages(isolate, str, array);
+  auto result = mdsf::message_parser::ParseJSTPMessages(isolate, *str, length,
+                                                        array);
   args.GetReturnValue().Set(result);
 }
 


### PR DESCRIPTION
Avoid using `strlen()` magic and explicitly check for `'\0'` character.

Refs: https://github.com/metarhia/jstp/pull/254