### PR TITLE
serde: add support for dollar signs in keys

### DIFF
--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -46,7 +46,7 @@ const STRINGIFIERS = {
         continue;
       }
 
-      if (!/^[a-zA-Z_]\w*$/.test(key)) {
+      if (!/^[a-zA-Z_$][\w$]*$/.test(key)) {
         key = STRINGIFIERS.string(key);
       }
 

--- a/test/fixtures/serde-test-cases/serde/object.js
+++ b/test/fixtures/serde-test-cases/serde/object.js
@@ -35,4 +35,9 @@ module.exports = [
     'address:{country:\'Ukraine\',city:\'Kiev\',zip:\'03056\',' +
     'street:\'Pobedy\',building:\'37\',floor:\'1\',room:\'158\'}}',
   },
+  {
+    name: 'object with identifier names as keys',
+    value: { $: 'dollar', _$_: 'multiple symbols' },
+    serialized: '{$:\'dollar\',_$_:\'multiple symbols\'}',
+  },
 ];

--- a/test/fixtures/todo/serde/serialization/object.js
+++ b/test/fixtures/todo/serde/serialization/object.js
@@ -7,11 +7,6 @@ module.exports = [
     serialized: '{42:true}',
   },
   {
-    name: 'object with identifier names as keys',
-    value: { $: 'dollar', _$_: 'multiple symbols' },
-    serialized: '{$:\'dollar\',_$_:\'multiple symbols\'}',
-  },
-  {
     name: 'object with identifier name, ' +
       'containing non-latin Unicode literals, as a key',
     value: { ümlåût: 'that\'s not really an ümlaüt, but this is' },


### PR DESCRIPTION
This will allow serializing dollar signs in object keys without quotes.